### PR TITLE
pin mlflow and python version to example

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -2,9 +2,11 @@ name: tutorial
 channels:
   - defaults
 dependencies:
-  - numpy>=1.14.3
-  - pandas>=1.0.0
-  - scikit-learn>0.19.1
+  - python=3.9.13
   - pip
   - pip:
-    - mlflow
+    - mlflow==1.30.0
+    - numpy>=1.14.3
+    - pandas>=1.0.0
+    - scikit-learn>0.19.1
+


### PR DESCRIPTION
Pin mlflow and python versions to fix broken behaviour:

```python
File "/home/.../miniconda3/lib/python3.9/genericpath.py", line 152, in _check_arg_types
    raise TypeError(f'{funcname}() argument must be str, bytes, or '
TypeError: join() argument must be str, bytes, or os.PathLike object, not 'dict'
```